### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3
+COPY . /app
+WORKDIR /app
+RUN pip3 install -r requirements.txt
+CMD python3 bot.py


### PR DESCRIPTION
Fails with:
```
Collecting git+https://github.com/Rapptz/discord.py@rewrite (from -r requirements.txt (line 2))
  Cloning https://github.com/Rapptz/discord.py (to revision rewrite) to /tmp/pip-req-build-dmp7weia
  Running command git clone -q https://github.com/Rapptz/discord.py /tmp/pip-req-build-dmp7weia
  WARNING: Did not find branch or tag 'rewrite', assuming revision or ref.
  Running command git checkout -q rewrite
  error: pathspec 'rewrite' did not match any file(s) known to git.
ERROR: Command "git checkout -q rewrite" failed with error code 1 in /tmp/pip-req-build-dmp7weia
The command '/bin/sh -c pip3 install -r requirements.txt' returned a non-zero code: 1
```
seems that the `git+https://github.com/Rapptz/discord.py@rewrite` in the requirements.txt points to a branch that no longer exists