### PR TITLE
Refresh Tachibot design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /__pycache__/
 .flake8
 .idea/
-token
 .vscode/
 src/
+image.tmp
+token

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea/
 token
 .vscode/
+src/

--- a/bot.py
+++ b/bot.py
@@ -23,7 +23,6 @@ class TachiBoti(discord.Client):
         self.tachi_id = 349436576037732353
         self.klient = kadal.Klient(loop=self.loop)
         self.anilist_cover_url = "https://img.anili.st/media/"
-        print("Starting...")
 
     async def format_embed(self, name, anime=False):
         try:

--- a/bot.py
+++ b/bot.py
@@ -37,7 +37,7 @@ class TachiBoti(discord.Client):
         title = (media.title.get("english")
                  or media.title.get("romaji")
                  or media.title.get("native"))
-        desc = "***" + ", ".join(media.genres) + "***\n"
+        desc = "**" + ", ".join(media.genres) + "**\n"
         if media.description is not None:
             desc += media.description[:256 - len(desc)] + f"... [(more)]({media.site_url})"
         # dirty half-fix until i figure something better out

--- a/bot.py
+++ b/bot.py
@@ -4,6 +4,8 @@ import re
 import discord
 import kadal
 
+import fast_colorthief
+import urllib.request
 
 class TachiBoti(discord.Client):
     def __init__(self):
@@ -33,10 +35,24 @@ class TachiBoti(discord.Client):
             desc += media.description[:256 - len(desc)] + f"... [(more)]({media.site_url})"
         # dirty half-fix until i figure something better out
         desc = desc.replace("<br>", "").replace("<i>", "").replace("</i>", "")
-        footer = re.sub(r'.*\.', '', str(media.format))
-        e = discord.Embed(title=title, description=desc, color=0x4286f4)
+        footer = re.sub(r".*\.", "", str(media.format))
+        title_cover_info = "https://img.anili.st/media/" + str(media.id) 
+
+        def title_cover_info_color(title_cover_info=title_cover_info,temp_file="tmp.jpg"):
+
+            opener = urllib.request.build_opener()
+            opener.addheaders = [("User-agent", "Mozilla/5.0")]
+            urllib.request.install_opener(opener)
+            urllib.request.urlretrieve(title_cover_info, temp_file)
+
+            palette_color = fast_colorthief.get_palette(temp_file, color_count=2, quality=100)
+            embed_color = "%02x%02x%02x" % palette_color[1]
+            os.remove(temp_file)
+            return embed_color
+
+        e = discord.Embed(title=title, description=desc, color=int(title_cover_info_color(), 16))
         e.set_footer(text=footer.replace("TV", "ANIME"))
-        e.set_thumbnail(url=media.cover_image)
+        e.set_image(url=title_cover_info)
         e.url = media.site_url
         return e
 

--- a/bot.py
+++ b/bot.py
@@ -52,6 +52,8 @@ class TachiBoti(discord.Client):
                     await f.close()
                     palette_color = await asyncio.get_running_loop().run_in_executor(None, functools.partial(fast_colorthief.get_palette, temp_img, color_count=2, quality=100))
                     embed_color = "%02x%02x%02x" % palette_color[1]
+                else:
+                    embed_color = "02A9FF"
 
         e = discord.Embed(title=title, description=desc, color=int(embed_color, 16))
         e.set_footer(text=footer.replace("TV", "ANIME").capitalize(), icon_url="https://anilist.co/img/logo_al.png")

--- a/bot.py
+++ b/bot.py
@@ -38,9 +38,14 @@ class TachiBoti(discord.Client):
                  or media.title.get("native"))
         desc = "***" + ", ".join(media.genres) + "***\n"
         if media.description is not None:
-            desc += media.description[:256 - len(desc)] + f"... [(more)]({media.site_url})"
+            desc += textwrap.shorten(media.description, width=256 - len(desc), placeholder="") + f"... [(more)]({media.site_url})"
         # dirty half-fix until i figure something better out
-        desc = re.sub(r"<[bri/]{1,2}>", "", desc, flags=re.I|re.M)
+        replacements = [
+            (r"</?i/?>", ""),
+            (r"</?br/?>", "\n")
+        ]
+        for regex, regex_replace in replacements:
+            desc = re.sub(regex, regex_replace, desc, flags=re.I|re.M)
         footer = re.sub(r".*\.", "", str(media.format))
         
         resp = await self.klient.session.get(f"{self.anilist_cover_url}{media.id}")

--- a/bot.py
+++ b/bot.py
@@ -53,7 +53,6 @@ class TachiBoti(discord.Client):
             return embed_color
 
         e = discord.Embed(title=title, description=desc, color=int(title_cover_info_color(), 16))
-        e.set_footer(text=footer.replace("TV", "ANIME"))
         e.set_footer(text=footer.replace("TV", "ANIME").capitalize())
         e.set_image(url=title_cover_info)
         e.timestamp = parse(str(media.start_date), fuzzy=True)

--- a/bot.py
+++ b/bot.py
@@ -7,6 +7,7 @@ import kadal
 import aiohttp        
 import aiofiles
 import asyncio
+import textwrap
 import functools
 import fast_colorthief
 

--- a/bot.py
+++ b/bot.py
@@ -40,7 +40,7 @@ class TachiBoti(discord.Client):
         footer = re.sub(r".*\.", "", str(media.format))
         title_cover_info = "https://img.anili.st/media/" + str(media.id) 
 
-        def title_cover_info_color(title_cover_info=title_cover_info,temp_file="tmp.jpg"):
+        def title_cover_info_color(title_cover_info=title_cover_info,temp_file="image.tmp"):
 
             opener = urllib.request.build_opener()
             opener.addheaders = [("User-agent", "Mozilla/5.0")]

--- a/bot.py
+++ b/bot.py
@@ -21,6 +21,7 @@ class TachiBoti(discord.Client):
         self.tachi_id = 349436576037732353
         self.tachi_id = 448601827542302730
         self.klient = kadal.Klient(loop=self.loop)
+        print("Starting...")
 
     async def format_embed(self, name, anime=False):
         try:
@@ -61,10 +62,11 @@ class TachiBoti(discord.Client):
         return e
 
     async def on_ready(self):
+        print("~-~-~-~-~-~-~-~-~-~-~")
+        print(f"Bot: {self.user.name}")
+        print(f"ID: {self.user.id}")
+        print("~-~-~-~-~-~-~-~-~-~-~")
         print("Ready!")
-        print(self.user.name)
-        print(self.user.id)
-        print("~-~-~-~-~")
 
     async def on_member_join(self, member):
         if member.guild.id != self.tachi_id:

--- a/bot.py
+++ b/bot.py
@@ -54,7 +54,7 @@ class TachiBoti(discord.Client):
                     embed_color = "%02x%02x%02x" % palette_color[1]
 
         e = discord.Embed(title=title, description=desc, color=int(embed_color, 16))
-        e.set_footer(text=footer.replace("TV", "ANIME").capitalize())
+        e.set_footer(text=footer.replace("TV", "ANIME").capitalize(), icon_url="https://anilist.co/img/logo_al.png")
         e.set_image(url=f"{self.anilist_cover_url}{media.id}")
         e.timestamp = parse(str(media.start_date), fuzzy=True)
         e.url = media.site_url

--- a/bot.py
+++ b/bot.py
@@ -43,25 +43,24 @@ class TachiBoti(discord.Client):
         desc = re.sub(r"<[bri/]{1,2}>", "", desc, flags=re.I|re.M)
         footer = re.sub(r".*\.", "", str(media.format))
         
-        async with aiohttp.ClientSession() as session:
-            async with session.get(f"{self.anilist_cover_url}{media.id}") as resp:
-                if resp.status == 200:
-                    temp_img = "image.tmp"
-                    async with aiofiles.open(temp_img, mode='wb') as f:
-                        await f.write(await resp.read())
-                    palette_partial = functools.partial(
-                        fast_colorthief.get_palette,
-                        temp_img,
-                        color_count=2,
-                        quality=100
-                    )
-                    palette_color = await self.loop.run_in_executor(
-                        None,
-                        palette_partial
-                    )
-                    embed_color = "%02x%02x%02x" % palette_color[1]
-                else:
-                    embed_color = "2F3136"
+        resp = await self.klient.session.get(f"{self.anilist_cover_url}{media.id}")
+        if resp.status == 200:
+            temp_img = "image.tmp"
+            async with aiofiles.open(temp_img, mode='wb') as f:
+                await f.write(await resp.read())
+            palette_partial = functools.partial(
+                fast_colorthief.get_palette,
+                temp_img,
+                color_count=2,
+                quality=100
+            )
+            palette_color = await self.loop.run_in_executor(
+                None,
+                palette_partial
+            )
+            embed_color = "%02x%02x%02x" % palette_color[1]
+        else:
+            embed_color = "2F3136"
 
         e = discord.Embed(title=title, description=desc, color=int(embed_color, 16))
         e.set_footer(text=footer.replace("TV", "ANIME").capitalize(), icon_url="https://anilist.co/img/logo_al.png")

--- a/bot.py
+++ b/bot.py
@@ -47,9 +47,8 @@ class TachiBoti(discord.Client):
             async with session.get(f"{self.anilist_cover_url}{media.id}") as resp:
                 if resp.status == 200:
                     temp_img = "image.tmp"
-                    f = await aiofiles.open(temp_img, mode='wb')
-                    await f.write(await resp.read())
-                    await f.close()
+                    async with aiofiles.open(temp_img, mode='wb') as f:
+                        await f.write(await resp.read())
                     palette_partial = functools.partial(
                         fast_colorthief.get_palette,
                         temp_img,

--- a/bot.py
+++ b/bot.py
@@ -5,7 +5,7 @@ import discord
 import kadal
 
 import aiohttp        
-import aiofiles.os
+import aiofiles
 import asyncio
 import functools
 import fast_colorthief

--- a/bot.py
+++ b/bot.py
@@ -37,7 +37,7 @@ class TachiBoti(discord.Client):
         title = (media.title.get("english")
                  or media.title.get("romaji")
                  or media.title.get("native"))
-        desc = "**" + ", ".join(media.genres) + "**\n"
+        desc = "***" + ", ".join(media.genres) + "***\n"
         if media.description is not None:
             desc += media.description[:256 - len(desc)] + f"... [(more)]({media.site_url})"
         # dirty half-fix until i figure something better out

--- a/bot.py
+++ b/bot.py
@@ -50,7 +50,16 @@ class TachiBoti(discord.Client):
                     f = await aiofiles.open(temp_img, mode='wb')
                     await f.write(await resp.read())
                     await f.close()
-                    palette_color = await asyncio.get_running_loop().run_in_executor(None, functools.partial(fast_colorthief.get_palette, temp_img, color_count=2, quality=100))
+                    palette_partial = functools.partial(
+                        fast_colorthief.get_palette,
+                        temp_img,
+                        color_count=2,
+                        quality=100
+                    )
+                    palette_color = await self.loop.run_in_executor(
+                        None,
+                        palette_partial
+                    )
                     embed_color = "%02x%02x%02x" % palette_color[1]
                 else:
                     embed_color = "02A9FF"

--- a/bot.py
+++ b/bot.py
@@ -34,7 +34,7 @@ class TachiBoti(discord.Client):
         if media.description is not None:
             desc += media.description[:256 - len(desc)] + f"... [(more)]({media.site_url})"
         # dirty half-fix until i figure something better out
-        desc = desc.replace("<br>", "").replace("<i>", "").replace("</i>", "")
+        desc = desc.replace("<br>", "").replace("<bR>", "").replace("<Br>", "").replace("<BR>", "").replace("<i>", "").replace("</i>", "").replace("<I>", "").replace("</I>", "")
         footer = re.sub(r".*\.", "", str(media.format))
         title_cover_info = "https://img.anili.st/media/" + str(media.id) 
 

--- a/bot.py
+++ b/bot.py
@@ -21,7 +21,6 @@ class TachiBoti(discord.Client):
         self.manga_regex = re.compile(r"<.*?https?:\/\/.*?>|<a?:.+?:\d*>|`[\s\S]*?`|<(.*?)>")
         self.anime_regex = re.compile(r"`[\s\S]*?`|{(.*?)}")
         self.tachi_id = 349436576037732353
-        self.tachi_id = 448601827542302730
         self.klient = kadal.Klient(loop=self.loop)
         print("Starting...")
 

--- a/bot.py
+++ b/bot.py
@@ -22,6 +22,7 @@ class TachiBoti(discord.Client):
         self.anime_regex = re.compile(r"`[\s\S]*?`|{(.*?)}")
         self.tachi_id = 349436576037732353
         self.klient = kadal.Klient(loop=self.loop)
+        self.anilist_cover_url = "https://img.anili.st/media/"
         print("Starting...")
 
     async def format_embed(self, name, anime=False):
@@ -43,10 +44,8 @@ class TachiBoti(discord.Client):
         desc = re.sub(r"<[bri/]{1,2}>", "", desc, flags=re.I|re.M)
         footer = re.sub(r".*\.", "", str(media.format))
         
-        title_cover_info = "https://img.anili.st/media/" + str(media.id) 
-
         async with aiohttp.ClientSession() as session:
-            async with session.get(title_cover_info) as resp:
+            async with session.get(f"{self.anilist_cover_url}{media.id}") as resp:
                 if resp.status == 200:
                     f = await aiofiles.open("image.tmp", mode='wb')
                     await f.write(await resp.read())
@@ -57,7 +56,7 @@ class TachiBoti(discord.Client):
 
         e = discord.Embed(title=title, description=desc, color=int(embed_color, 16))
         e.set_footer(text=footer.replace("TV", "ANIME").capitalize())
-        e.set_image(url=title_cover_info)
+        e.set_image(url=f"{self.anilist_cover_url}{media.id}")
         e.timestamp = parse(str(media.start_date), fuzzy=True)
         e.url = media.site_url
         return e

--- a/bot.py
+++ b/bot.py
@@ -52,7 +52,6 @@ class TachiBoti(discord.Client):
                     await f.close()
                     palette_color = await asyncio.get_running_loop().run_in_executor(None, functools.partial(fast_colorthief.get_palette, "image.tmp", color_count=2, quality=100))
                     embed_color = "%02x%02x%02x" % palette_color[1]
-                    await aiofiles.os.remove("image.tmp")
 
         e = discord.Embed(title=title, description=desc, color=int(embed_color, 16))
         e.set_footer(text=footer.replace("TV", "ANIME").capitalize())

--- a/bot.py
+++ b/bot.py
@@ -6,6 +6,8 @@ import kadal
 
 import aiohttp        
 import aiofiles.os
+import asyncio
+import functools
 import fast_colorthief
 
 from dateutil.parser import parse
@@ -50,7 +52,7 @@ class TachiBoti(discord.Client):
                     f = await aiofiles.open("image.tmp", mode='wb')
                     await f.write(await resp.read())
                     await f.close()
-                    palette_color = fast_colorthief.get_palette("image.tmp", color_count=2, quality=100)
+                    palette_color = await asyncio.get_running_loop().run_in_executor(None, functools.partial(fast_colorthief.get_palette, "image.tmp", color_count=2, quality=100))
                     embed_color = "%02x%02x%02x" % palette_color[1]
                     await aiofiles.os.remove("image.tmp")
 

--- a/bot.py
+++ b/bot.py
@@ -61,7 +61,7 @@ class TachiBoti(discord.Client):
                     )
                     embed_color = "%02x%02x%02x" % palette_color[1]
                 else:
-                    embed_color = "02A9FF"
+                    embed_color = "2F3136"
 
         e = discord.Embed(title=title, description=desc, color=int(embed_color, 16))
         e.set_footer(text=footer.replace("TV", "ANIME").capitalize(), icon_url="https://anilist.co/img/logo_al.png")

--- a/bot.py
+++ b/bot.py
@@ -47,10 +47,11 @@ class TachiBoti(discord.Client):
         async with aiohttp.ClientSession() as session:
             async with session.get(f"{self.anilist_cover_url}{media.id}") as resp:
                 if resp.status == 200:
-                    f = await aiofiles.open("image.tmp", mode='wb')
+                    temp_img = "image.tmp"
+                    f = await aiofiles.open(temp_img, mode='wb')
                     await f.write(await resp.read())
                     await f.close()
-                    palette_color = await asyncio.get_running_loop().run_in_executor(None, functools.partial(fast_colorthief.get_palette, "image.tmp", color_count=2, quality=100))
+                    palette_color = await asyncio.get_running_loop().run_in_executor(None, functools.partial(fast_colorthief.get_palette, temp_img, color_count=2, quality=100))
                     embed_color = "%02x%02x%02x" % palette_color[1]
 
         e = discord.Embed(title=title, description=desc, color=int(embed_color, 16))

--- a/bot.py
+++ b/bot.py
@@ -27,9 +27,9 @@ class TachiBoti(discord.Client):
         except kadal.MediaNotFound:
             return
 
-        title = (media.title.get('english')
-                 or media.title.get('romaji')
-                 or media.title.get('native'))
+        title = (media.title.get("english")
+                 or media.title.get("romaji")
+                 or media.title.get("native"))
         desc = "***" + ", ".join(media.genres) + "***\n"
         if media.description is not None:
             desc += media.description[:256 - len(desc)] + f"... [(more)]({media.site_url})"

--- a/bot.py
+++ b/bot.py
@@ -36,7 +36,7 @@ class TachiBoti(discord.Client):
         if media.description is not None:
             desc += media.description[:256 - len(desc)] + f"... [(more)]({media.site_url})"
         # dirty half-fix until i figure something better out
-        desc = desc.replace("<br>", "").replace("<bR>", "").replace("<Br>", "").replace("<BR>", "").replace("<i>", "").replace("</i>", "").replace("<I>", "").replace("</I>", "")
+        desc = re.sub(r"<[bri/]{1,2}>", "", desc, flags=re.I|re.M)
         footer = re.sub(r".*\.", "", str(media.format))
         title_cover_info = "https://img.anili.st/media/" + str(media.id) 
 

--- a/bot.py
+++ b/bot.py
@@ -7,6 +7,8 @@ import kadal
 import fast_colorthief
 import urllib.request
 
+from dateutil.parser import parse
+
 class TachiBoti(discord.Client):
     def __init__(self):
         super().__init__()
@@ -52,7 +54,9 @@ class TachiBoti(discord.Client):
 
         e = discord.Embed(title=title, description=desc, color=int(title_cover_info_color(), 16))
         e.set_footer(text=footer.replace("TV", "ANIME"))
+        e.set_footer(text=footer.replace("TV", "ANIME").capitalize())
         e.set_image(url=title_cover_info)
+        e.timestamp = parse(str(media.start_date), fuzzy=True)
         e.url = media.site_url
         return e
 


### PR DESCRIPTION
This should be prefaced with that I don't know Python at all so I just experimented until it worked and looked decent.

Estimated required bandwidth for the dominant color system = **300 MB**/month for **1000** messages (last period in Tachiyomi server).

On Windows machines, [`fast_colorthief`](https://github.com/bedapisl/fast-colorthief) has to be built manually with CMake.

## Changes
- Adds AniList embed thumbnail as the image
- Gets the image dominant color and uses it for embed color
- Changes casing on manga format
- Adds startedDate as timestamp
- Fix some quotation marks so it's more consistent
- Since `replace` is case sensitive, it wouldn't catch `<bR>`, `<Br>`, `<BR>`, `<I>` and `</I>` from descriptions – that's fixed.

## Preview
Old | New
------------ | -------------
![image](https://user-images.githubusercontent.com/10836780/105189307-1fcf3680-5b35-11eb-97f1-e813f36e149b.png) | ![image](https://user-images.githubusercontent.com/10836780/105189208-03cb9500-5b35-11eb-95a8-dd1a6a5c07ab.png)